### PR TITLE
Add cookie-free analytics to measure page views

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,9 +10,21 @@
   <link href="https://fonts.googleapis.com/css?family=Work+Sans:300,400,600&display=swap" rel="stylesheet">
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"
+    integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4"
+    crossorigin="anonymous"></script>
   <script src="{{ site.baseurl }}/assets/app.js"></script>
+  <script type="text/javascript" src="https://js.monitor.azure.com/scripts/c/ms.analytics-web-3.min.js">
+  </script>
 
   <title>{{ page.page_title }}</title>
-  <meta name="description" content="{{ page.page_description }}" >
+  <meta name="description" content="{{ page.page_description }}">
+  <script>
+    const analytics = new oneDS.ApplicationInsights();
+    var config = {
+      instrumentationKey: "734e91f5b0594dd08e2e4768fb4f9655",
+      disableCookiesUsage: true
+    };
+    analytics.initialize(config, []);
+  </script>
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,7 +22,7 @@
   <script>
     const analytics = new oneDS.ApplicationInsights();
     var config = {
-      instrumentationKey: "734e91f5b0594dd08e2e4768fb4f9655",
+      instrumentationKey: "734e91f5b0594dd08e2e4768fb4f9655-a7347ca4-1142-4c1e-831a-372cd2790ac0-6806",
       disableCookiesUsage: true
     };
     analytics.initialize(config, []);


### PR DESCRIPTION
This explicitly disables cookie usage since we really just want to use simple page views to understand which pages are typically viewed and where we can direct our attention. We do not want to implement invasive tracking or anything like that.